### PR TITLE
Readded entity fire events

### DIFF
--- a/game/server/player.cpp
+++ b/game/server/player.cpp
@@ -6774,11 +6774,14 @@ void CBasePlayer::UpdateClientData( void )
 			{
 				variant_t value;
 				g_EventQueue.AddEvent( "game_player_manager", "OnPlayerJoin", value, 0, this, this );
+				FireTargets( "game_playerjoin", this, this, USE_TOGGLE, 0 );
 			}
 		}
 
 		variant_t value;
 		g_EventQueue.AddEvent( "game_player_manager", "OnPlayerSpawn", value, 0, this, this );
+		//fix: oh my god why did they remove this
+		FireTargets( "game_playerspawn", this, this, USE_TOGGLE, 0 );
 	}
 
 	// HACKHACK -- send the message to display the game title

--- a/game/shared/hl2mp/hl2mp_gamerules.cpp
+++ b/game/shared/hl2mp/hl2mp_gamerules.cpp
@@ -646,6 +646,8 @@ void CHL2MPRules::ClientDisconnected( edict_t *pClient )
 	CBasePlayer *pPlayer = (CBasePlayer *)CBaseEntity::Instance( pClient );
 	if ( pPlayer )
 	{
+		FireTargets( "game_playerleave", pPlayer, pPlayer, USE_TOGGLE, 0 );
+		
 		// Remove the player from his team
 		if ( pPlayer->GetTeam() )
 		{


### PR DESCRIPTION
As of right now, [this section of the article on the Valve Software developer wiki](https://developer.valvesoftware.com/wiki/Targetname#Keywords) is a complete lie.
![image](https://github.com/SourceBoxGame/SourceBox/assets/42327589/a84a7cf5-912f-4303-90c9-4bab7df95722)
Half of them don't do anything because they were replaced with `game_player_manager` events sometime ago and I don't know when. This reimplements the behavior it describes.