### PR TITLE
Customizable hud colors

### DIFF
--- a/game/client/hl1/hl1_clientmode.cpp
+++ b/game/client/hl1/hl1_clientmode.cpp
@@ -83,7 +83,7 @@ protected:
 	{
 		BaseClass::ApplySchemeSettings( pScheme );
 
-		gHUD.InitColors( pScheme );
+		gHUD.InitColors();
 
 		SetPaintBackgroundEnabled( false );
 	}

--- a/game/client/hl2/clientmode_hlnormal.cpp
+++ b/game/client/hl2/clientmode_hlnormal.cpp
@@ -48,7 +48,7 @@ protected:
 	{
 		BaseClass::ApplySchemeSettings( pScheme );
 
-		gHUD.InitColors( pScheme );
+		gHUD.InitColors();
 
 		SetPaintBackgroundEnabled( false );
 	}

--- a/game/client/hl2mp/clientmode_hl2mpnormal.cpp
+++ b/game/client/hl2mp/clientmode_hl2mpnormal.cpp
@@ -60,7 +60,7 @@ protected:
 	{
 		BaseClass::ApplySchemeSettings( pScheme );
 
-		gHUD.InitColors( pScheme );
+		gHUD.InitColors();
 
 		SetPaintBackgroundEnabled( false );
 	}

--- a/game/client/hud.cpp
+++ b/game/client/hud.cpp
@@ -471,14 +471,21 @@ void CHud::Init( void )
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: Update Hud global colors
+//-----------------------------------------------------------------------------
+void CHud::UpdateColors()
+{
+	m_clrNormal = 	 Color( sb_hud_normR->GetInt(), sb_hud_normG->GetInt(), sb_hud_normB->GetInt(), sb_hud_normA->GetInt() );
+	m_clrCaution =	 Color( sb_hud_cautR->GetInt(), sb_hud_cautG->GetInt(), sb_hud_cautB->GetInt(), sb_hud_cautA->GetInt() );
+	m_clrYellowish = Color( sb_hud_yellR->GetInt(), sb_hud_yellG->GetInt(), sb_hud_yellB->GetInt(), sb_hud_yellA->GetInt() );
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: Init Hud global colors
-// Input  : *scheme - 
 //-----------------------------------------------------------------------------
 void CHud::InitColors( vgui::IScheme *scheme )
 {
-	m_clrNormal = scheme->GetColor( "Normal", Color( 255, 208, 64 ,255 ) );
-	m_clrCaution = scheme->GetColor( "Caution", Color( 255, 48, 0, 255 ) );
-	m_clrYellowish = scheme->GetColor( "Yellowish", Color( 255, 160, 0, 255 ) );
+	UpdateColors();
 }
 
 //-----------------------------------------------------------------------------

--- a/game/client/hud.h
+++ b/game/client/hud.h
@@ -122,7 +122,7 @@ public:
 	void						ProcessInput( bool bActive );
 	void						UpdateHud( bool bActive );
 
-	void						InitColors( vgui::IScheme *pScheme );
+	void						InitColors();
 
 	// Hud element registration
 	void						AddHudElement( CHudElement *pHudElement );
@@ -170,9 +170,24 @@ public:
 #endif
 	float						m_flFOVSensitivityAdjust;
 
+	void 						UpdateColors();
 	Color						m_clrNormal;
+	ConVar						sb_hud_normR("sb_hud_normal_R", 255, FCVAR_ARCHIVE|FCVAR_DONTRECORD, "Red value for normal hud status.", true, 0, true, 255, UpdateColors);
+	ConVar						sb_hud_normG("sb_hud_normal_G", 220, FCVAR_ARCHIVE|FCVAR_DONTRECORD, "Green value for normal hud status.", true, 0, true, 255, UpdateColors);
+	ConVar						sb_hud_normB("sb_hud_normal_B", 0, FCVAR_ARCHIVE|FCVAR_DONTRECORD, "Blue value for normal hud status.", true, 0, true, 255, UpdateColors);
+	ConVar						sb_hud_normA("sb_hud_normal_A", 255, FCVAR_ARCHIVE|FCVAR_DONTRECORD, "Alpha value for normal hud status.", true, 0, true, 255, UpdateColors);
+	
 	Color						m_clrCaution;
+	ConVar						sb_hud_cautR("sb_hud_caution_R", 255, FCVAR_ARCHIVE|FCVAR_DONTRECORD, "Red value for cautious hud status.", true, 0, true, 255, UpdateColors);
+	ConVar						sb_hud_cautG("sb_hud_caution_G", 48, FCVAR_ARCHIVE|FCVAR_DONTRECORD, "Green value for cautious hud status.", true, 0, true, 255, UpdateColors);
+	ConVar						sb_hud_cautB("sb_hud_caution_b", 0, FCVAR_ARCHIVE|FCVAR_DONTRECORD, "Blue value for cautious hud status.", true, 0, true, 255, UpdateColors);
+	ConVar						sb_hud_cautA("sb_hud_caution_A", 255, FCVAR_ARCHIVE|FCVAR_DONTRECORD, "Alpha value for cautious hud status.", true, 0, true, 255, UpdateColors);
+	
 	Color						m_clrYellowish;
+	ConVar						sb_hud_yellR("sb_hud_yellowish_R", 255, FCVAR_ARCHIVE|FCVAR_DONTRECORD, "Red value for yellowish hud status.", true, 0, true, 255, UpdateColors);
+	ConVar						sb_hud_yellG("sb_hud_yellowish_G", 48, FCVAR_ARCHIVE|FCVAR_DONTRECORD, "Green value for yellowish hud status.", true, 0, true, 255, UpdateColors);
+	ConVar						sb_hud_yellB("sb_hud_yellowish_b", 0, FCVAR_ARCHIVE|FCVAR_DONTRECORD, "Blue value for yellowish hud status.", true, 0, true, 255, UpdateColors);
+	ConVar						sb_hud_yellA("sb_hud_yellowish_A", 255, FCVAR_ARCHIVE|FCVAR_DONTRECORD, "Alpha value for yellowish hud status.", true, 0, true, 255, UpdateColors);
 
 	CUtlVector< CHudElement * >	m_HudList;
 

--- a/game/client/portal/clientmode_portal.cpp
+++ b/game/client/portal/clientmode_portal.cpp
@@ -91,7 +91,7 @@ protected:
 	{
 		BaseClass::ApplySchemeSettings( pScheme );
 
-		gHUD.InitColors( pScheme );
+		gHUD.InitColors();
 
 		SetPaintBackgroundEnabled( false );
 	}


### PR DESCRIPTION
This adds a way to control HUD colors via cvar.
This adds...
```
sb_hud_normal_*
sb_hud_caution_*
sb_hud_yellowish_*
```
...with `*` meaning `R`, `G`, `B`, or `A`.